### PR TITLE
 Fixing hidden End() function that is never called

### DIFF
--- a/offline/packages/trackreco/PHInitVertexing.h
+++ b/offline/packages/trackreco/PHInitVertexing.h
@@ -42,7 +42,6 @@ class PHInitVertexing : public SubsysReco
   /// implemented in derived classes
   virtual int Process(PHCompositeNode *topNode) = 0;
 
-  virtual int End() = 0;
 
   TrkrClusterContainer *_cluster_map;
   SvtxVertexMap *_vertex_map;

--- a/offline/packages/trackreco/PHInitZVertexing.cc
+++ b/offline/packages/trackreco/PHInitZVertexing.cc
@@ -471,7 +471,7 @@ int PHInitZVertexing::Process(PHCompositeNode* topNode)
 	return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHInitZVertexing::End() {
+int PHInitZVertexing::End(PHCompositeNode * /*topNode*/) {
 #ifdef _DEBUG_
 	_ofile->cd();
 	_z0_dzdl->Write();

--- a/offline/packages/trackreco/PHInitZVertexing.h
+++ b/offline/packages/trackreco/PHInitZVertexing.h
@@ -150,7 +150,7 @@ public:
 
   int Setup(PHCompositeNode *topNode);
   int Process(PHCompositeNode *topNode);
-  int End();
+  int End(PHCompositeNode * /*topNode*/);
 
 private:
 

--- a/offline/packages/trackreco/PHTruthVertexing.cc
+++ b/offline/packages/trackreco/PHTruthVertexing.cc
@@ -110,7 +110,7 @@ int PHTruthVertexing::GetNodes(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int PHTruthVertexing::End()
+int PHTruthVertexing::End(PHCompositeNode * /*topNode*/)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/offline/packages/trackreco/PHTruthVertexing.h
+++ b/offline/packages/trackreco/PHTruthVertexing.h
@@ -46,7 +46,7 @@ class PHTruthVertexing : public PHInitVertexing
 
   int Process(PHCompositeNode *topNode);
 
-  int End();
+  int End(PHCompositeNode * /*topNode*/);
 
  private:
   /// fetch node pointers


### PR DESCRIPTION
Following clang check report here: 
https://web.racf.bnl.gov/jenkins-sphenix/job/sPHENIX/job/Build-Clang/152/clang/New/category.2051178081/source.0af54aa4-e52e-4daa-b481-d66d11ba8827/#45
End() functions was never called in the current implimentation. 

This should fix it. However, I have not tested it in running though. 