### PR TITLE
Change ACTFW include to match sPHENIX fork of ACTFW

### DIFF
--- a/offline/packages/trackreco/PHActsTrkFitter.cc
+++ b/offline/packages/trackreco/PHActsTrkFitter.cc
@@ -70,7 +70,7 @@
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "ACTFW/Detector/IBaseDetector.hpp"
-#include "ACTFW/Io/Root/RootMaterialDecorator.hpp"
+#include "ACTFW/Plugins/Root/RootMaterialDecorator.hpp"
 
 #include <Acts/Geometry/GeometryContext.hpp>
 #include <Acts/Geometry/TrackingGeometry.hpp>


### PR DESCRIPTION
When trying to build the PHActsTrkFitter I got a compile error that says 
```
../PHActsTrkFitter.cc:73:10: fatal error: ACTFW/Io/Root/RootMaterialDecorator.hpp: No such file or directory
 #include "ACTFW/Io/Root/RootMaterialDecorator.hpp"
```

The reason is that the sPHENIX implementation of ACTFW installs this header into `ACTFW/Plugins/Root/RootMaterialDecorator.hpp`. I'm guessing this include is leftover from when Tony was just copying include files to the places they need to be. This PR should fix that and make PHActsTrkFitter able to build out of the box using the sPHENIX ACTFW repo mirror.